### PR TITLE
Define carla host and port

### DIFF
--- a/carla_connect/addcam.py
+++ b/carla_connect/addcam.py
@@ -36,7 +36,8 @@ class CameraDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         super(CameraDockWidget, self).__init__(parent)
         self.setupUi(self)
         self.height = None
-        self.auto_cam_placement = AutoCamera()
+        self.world = MapUpdate().get_world()
+        self.auto_cam_placement = AutoCamera(self.world)
         self.AddCameraposition.pressed.connect(self._insert_camera)
         self.AddCamerabutton.pressed.connect(self.auto_cam_placement.auto_camera_placement)
         self.cameraheight.currentTextChanged.connect(self._camera_height)
@@ -81,7 +82,7 @@ class CameraDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         QgsMessageLog.logMessage("Using existing vehicle layer", level=Qgis.Info)
         canvas = iface.mapCanvas()
         layer = iface.mapCanvas().currentLayer()
-        tool = PointTool(canvas, layer, self.height)
+        tool = PointTool(canvas, layer, self.height, self.world)
         canvas.setMapTool(tool)
 
 class PointTool(QgsMapTool):
@@ -91,11 +92,12 @@ class PointTool(QgsMapTool):
     canvas: iface map canvas.
     layers: iface current layer.
     '''
-    def __init__(self, canvas, layer, height):
+    def __init__(self, canvas, layer, height, world):
         QgsMapTool.__init__(self, canvas)
         self.canvas = canvas
         self.layer = layer
         self.height = height
+        self.world = world
         self.data_input = layer.dataProvider()
         self.canvas.setCursor(Qt.CrossCursor)
 
@@ -120,7 +122,7 @@ class PointTool(QgsMapTool):
         feature.setAttributes([float(enupoint.x), float(enupoint.y)])
         feature.setGeometry(QgsGeometry.fromPolygonXY([squarepoint]))
         # Call function spawn_camera which spawn camera at provided location
-        self.spawn_cam = Spawn()
+        self.spawn_cam = Spawn(self.world)
         if self.height is None:
             self.height = 10
         self.spawn_cam.spawn_camera(enupoint.x, enupoint.y, self.height)
@@ -186,12 +188,13 @@ class PointTool(QgsMapTool):
             return squarepoints
 
 class AutoCamera():
-    def __init__(self):
+    def __init__(self, world):
         '''
         Initilize the variable.
         '''
         self.actors_x_position = np.array([])
         self.actors_y_position = np.array([])
+        self.world = world
 
     def auto_camera_placement(self):
         '''
@@ -242,7 +245,7 @@ class AutoCamera():
         camera_position_x = sum_x / length
         camera_position_y = sum_y / length
         cameraposition = ad.map.point.createENUPoint(x=camera_position_x, y=camera_position_y, z=0)
-        spawn_cam = Spawn()
+        spawn_cam = Spawn(self.world)
         spawn_cam.spawn_camera(cameraposition.x, cameraposition.y, 50)
 
 class Spawn():
@@ -254,11 +257,11 @@ class Spawn():
     height = how high the camera has to be placed
     '''
     actor_list = []
-    def __init__(self):
+    def __init__(self, world):
         '''
         initialize variable
         '''
-        self.world = MapUpdate().get_world()
+        self.world = world
 
     def spawn_camera(self, positionx, positiony, height):
         '''
@@ -273,8 +276,8 @@ class ImageProcessor():
     '''
     class to set up py_gam window and process image
     '''
-    def __init__(self):
-        self.world = MapUpdate().get_world()
+    def __init__(self, world):
+        self.world = world
         self.actor_list = self.world.get_actors()
         self.width = 1200
         self.height = 1200

--- a/carla_connect/addcam.py
+++ b/carla_connect/addcam.py
@@ -31,12 +31,12 @@ FORM_CLASS, _ = uic.loadUiType(os.path.join(
 class CameraDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     '''class for Qtwidget of camera placement'''
     closingPlugin = pyqtSignal()
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, host='localhost', port=2000):
         self.camera_layer = None
         super(CameraDockWidget, self).__init__(parent)
         self.setupUi(self)
         self.height = None
-        self.world = MapUpdate().get_world()
+        self.world = MapUpdate(host, port).get_world()
         self.auto_cam_placement = AutoCamera(self.world)
         self.AddCameraposition.pressed.connect(self._insert_camera)
         self.AddCamerabutton.pressed.connect(self.auto_cam_placement.auto_camera_placement)

--- a/carla_connect/carla_connect_dockwidget.py
+++ b/carla_connect/carla_connect_dockwidget.py
@@ -28,13 +28,15 @@ class CarlaConnectDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     '''
     closingPlugin = pyqtSignal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, host='localhost', port=2000):
         """Constructor."""
         super(CarlaConnectDockWidget, self).__init__(parent)
         self.setupUi(self)
         self.combo_box.clear()
         self.iface = iface
-        self.update_map = MapUpdate()
+        self.host = host
+        self.port = port
+        self.update_map = MapUpdate(self.host, self.port)
         self.maps = self._get_maps()
         self.combo_box.addItems(self.maps)
         self.combo_box.currentTextChanged.connect(self._change_town)

--- a/carla_connect/carla_connect_dockwidget.py
+++ b/carla_connect/carla_connect_dockwidget.py
@@ -48,7 +48,7 @@ class CarlaConnectDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.selected_town = None
         self._scenario_runner_process = None
         self.world = self.update_map.get_world()
-        self.camera_visualization = ImageProcessor()
+        self.camera_visualization = ImageProcessor(self.world)
 
     def _get_maps(self):
         self.maps_available = self.update_map.get_available_map()

--- a/carla_connect/carla_connect_dockwidget.py
+++ b/carla_connect/carla_connect_dockwidget.py
@@ -99,7 +99,11 @@ class CarlaConnectDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             file = pathlib.Path(scenario_runner_path)
             if file.exists():
                 try:
-                    self._scenario_runner_process = Popen(['python3', scenario_runner_path, '--reloadWorld', '--openscenario', '/tmp/scenariogenerator1.xosc'])
+                    self._scenario_runner_process = Popen(['python3', scenario_runner_path,
+                                                           '--reloadWorld',
+                                                           '--openscenario', '/tmp/scenariogenerator1.xosc',
+                                                           '--host', self.host,
+                                                           '--port', str(self.port)])
                 except RuntimeError as error:
                     print('RuntimeError: {}'.format(error))
                     print(' Could not run the scenario.')

--- a/carla_connect/carla_connect_to_host.py
+++ b/carla_connect/carla_connect_to_host.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2021 FZI Forschungszentrum Informatik
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+"""
+Carla_connect - Connect to CARLA
+"""
+import os.path
+# pylint: disable=no-name-in-module,no-member
+from qgis.core import Qgis, QgsMessageLog
+from qgis.PyQt import QtWidgets, uic
+from qgis.utils import iface
+
+FORM_CLASS, _ = uic.loadUiType(os.path.join(
+    os.path.dirname(__file__), 'carla_connect_to_host_dialog.ui'))
+
+class CarlaConnectToHostDialog(QtWidgets.QDialog, FORM_CLASS):
+    """
+    Dialog class for connecting to CARLA.
+    """
+    def __init__(self, parent=None):
+        """Initialization of CarlaConnectToHostDialog"""
+        super(CarlaConnectToHostDialog, self).__init__(parent)
+        self.setupUi(self)
+
+    def get_host_and_port(self):
+        """Returns host and port selection from GUI"""
+        host = "localhost"
+        port = 2000
+        if self.host_selection.text() is not "":
+            host = str(self.host_selection.text())
+        else:
+            message = "No CARLA host was selected, defaulting to 'localhost'"
+            iface.messageBar().pushMessage("Info", message, level=Qgis.Info)
+            QgsMessageLog.logMessage(message, level=Qgis.Info)
+        if self.port_selection.text() is not "":
+            port = int(self.port_selection.text())
+        else:
+            message = "No CARLA port was selected, defaulting to 2000"
+            iface.messageBar().pushMessage("Info", message, level=Qgis.Info)
+            QgsMessageLog.logMessage(message, level=Qgis.Info)
+        return [host, port]

--- a/carla_connect/carla_connect_to_host_dialog.ui
+++ b/carla_connect/carla_connect_to_host_dialog.ui
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>374</width>
+    <height>105</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Connect to CARLA</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="1" colspan="2">
+    <widget class="QLineEdit" name="port_selection">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>2000</string>
+     </property>
+     <property name="cursorPosition">
+      <number>1</number>
+     </property>
+     <property name="placeholderText">
+      <string>2000</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="host_selection_label">
+     <property name="text">
+      <string>CARLA host</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="port_selection_label">
+     <property name="text">
+      <string>CARLA port</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="host_selection">
+     <property name="text">
+      <string>localhost</string>
+     </property>
+     <property name="cursorPosition">
+      <number>0</number>
+     </property>
+     <property name="placeholderText">
+      <string>localhost</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>278</x>
+     <y>190</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>169</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>278</x>
+     <y>190</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>169</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/carla_connect/mapupdate.py
+++ b/carla_connect/mapupdate.py
@@ -31,17 +31,14 @@ class MapUpdate():
     '''
     Class to read, load, change map from carla.
     '''
-    
-    host = 'localhost'
-    port = 2000
 
-    def __init__(self):
+    def __init__(self, host='localhost', port=2000):
         '''
         Connects to carla running in background.
         '''
         try:
-            self.carla_client = carla.Client(self.host, self.port)
-            if self.host == 'localhost':
+            self.carla_client = carla.Client(host, port)
+            if host == 'localhost':
                 self.carla_client.set_timeout(5.0)
             else:
                 self.carla_client.set_timeout(15.0)

--- a/carla_connect/mapupdate.py
+++ b/carla_connect/mapupdate.py
@@ -41,7 +41,10 @@ class MapUpdate():
         '''
         try:
             self.carla_client = carla.Client(self.host, self.port)
-            self.carla_client.set_timeout(5.0)
+            if self.host == 'localhost':
+                self.carla_client.set_timeout(5.0)
+            else:
+                self.carla_client.set_timeout(15.0)
         except RuntimeError as error:
             print('RuntimeError: {}'.format(error))
             print(' Could not connect to carla instint.')

--- a/carla_connect/mapupdate.py
+++ b/carla_connect/mapupdate.py
@@ -31,12 +31,16 @@ class MapUpdate():
     '''
     Class to read, load, change map from carla.
     '''
+    
+    host = 'localhost'
+    port = 2000
+
     def __init__(self):
         '''
         Connects to carla running in background.
         '''
         try:
-            self.carla_client = carla.Client('localhost', 2000)
+            self.carla_client = carla.Client(self.host, self.port)
             self.carla_client.set_timeout(5.0)
         except RuntimeError as error:
             print('RuntimeError: {}'.format(error))

--- a/carla_scenario_editor.py
+++ b/carla_scenario_editor.py
@@ -435,9 +435,7 @@ class OSC_Generator:
         message = "Loading Map"
         self.iface.messageBar().pushMessage("Info", message, level=Qgis.Info)
         QgsMessageLog.logMessage(message, level=Qgis.Info)
-        MapUpdate.host = self.host
-        MapUpdate.port = self.port
-        self.update_map = MapUpdate()
+        self.update_map = MapUpdate(self.host, self.port)
         self.update_map.read_map()
         self.update_map.map_init()
         self.update_map.map_update()

--- a/carla_scenario_editor.py
+++ b/carla_scenario_editor.py
@@ -33,6 +33,7 @@ try:
     from .carla_connect.mapupdate import MapUpdate
     from .carla_connect.addcam import CameraDockWidget
     from .carla_connect.carla_connect_dockwidget import CarlaConnectDockWidget
+    from .carla_connect.carla_connect_to_host import CarlaConnectToHostDialog
     carla_available = True
 except:
     carla_available = False
@@ -302,6 +303,19 @@ class OSC_Generator:
             self.iface.addDockWidget(Qt.BottomDockWidgetArea, self._dockwidget_pedestrians)
             self._dockwidget_pedestrians.show()
 
+    def get_carla_host_and_port(self):
+        """
+        Opens "Connect to CARLA" dialog.
+        """
+        dlg = CarlaConnectToHostDialog()
+        dlg.show()
+        return_value = dlg.exec_()
+        if return_value:
+            self.host, self.port = CarlaConnectToHostDialog.get_host_and_port(dlg)
+            return True
+        else:
+            return False
+
     def export_xosc(self):
         """
         Opens "Export OpenSCENARIO" dialog.
@@ -412,9 +426,17 @@ class OSC_Generator:
             QgsMessageLog.logMessage(message, level=Qgis.Info)
             return
 
+        if not self.get_carla_host_and_port():
+            message = "Did not specify CARLA host and port"
+            self.iface.messageBar().pushMessage("Info", message, level=Qgis.Info)
+            QgsMessageLog.logMessage(message, level=Qgis.Info)
+            return
+
         message = "Loading Map"
         self.iface.messageBar().pushMessage("Info", message, level=Qgis.Info)
         QgsMessageLog.logMessage(message, level=Qgis.Info)
+        MapUpdate.host = self.host
+        MapUpdate.port = self.port
         self.update_map = MapUpdate()
         self.update_map.read_map()
         self.update_map.map_init()

--- a/carla_scenario_editor.py
+++ b/carla_scenario_editor.py
@@ -443,7 +443,7 @@ class OSC_Generator:
         self.iface.messageBar().pushMessage("Info", message, level=Qgis.Info)
         QgsMessageLog.logMessage(message, level=Qgis.Info)
         if not self.pluginIsActive:
-            self.dockwidget = CarlaConnectDockWidget()
+            self.dockwidget = CarlaConnectDockWidget(host=self.host, port=self.port)
             self.dockwidget.closingPlugin.connect(self.onClosePlugin)
             self.iface.addDockWidget(Qt.LeftDockWidgetArea, self.dockwidget)
             self.dockwidget.show()
@@ -460,7 +460,14 @@ class OSC_Generator:
             self.iface.messageBar().pushMessage("Info", message, level=Qgis.Info)
             QgsMessageLog.logMessage(message, level=Qgis.Info)
             return
-        self.camera_dock_widget = CameraDockWidget()
+
+        if not self.get_carla_host_and_port():
+            message = "Did not specify CARLA host and port"
+            self.iface.messageBar().pushMessage("Info", message, level=Qgis.Info)
+            QgsMessageLog.logMessage(message, level=Qgis.Info)
+            return
+            
+        self.camera_dock_widget = CameraDockWidget(host=self.host, port=self.port)
         self.iface.addDockWidget(Qt.LeftDockWidgetArea, self.camera_dock_widget)
         self.camera_dock_widget.show()
 


### PR DESCRIPTION
By default, the plugin tries to connect to CARLA running on localhost, port 2000 and there is no option to input other values.

I added an additional dialog window to input host and port other than the default values. The dialog is opened after clicking the plugin's "Connect to carla" button.

![image](https://user-images.githubusercontent.com/28296759/115276297-26c11180-a143-11eb-94b9-7119e11e61ab.png)
