### PR TITLE
Set initial values for environment variables

### DIFF
--- a/osc_generator/export_xosc.py
+++ b/osc_generator/export_xosc.py
@@ -515,7 +515,7 @@ class GenerateXML():
         sun_elevation = "1.31"
         percip_type = "dry"
         percip_intensity = "0"
-        
+
         try:
             env_layer = QgsProject.instance().mapLayersByName("Environment")[0]
             for feature in env_layer.getFeatures():

--- a/osc_generator/export_xosc.py
+++ b/osc_generator/export_xosc.py
@@ -505,6 +505,17 @@ class GenerateXML():
         Args:
             init_act: [XML element]
         """
+        # Set initial values for environment variables
+        time_of_day = "2020-10-23T06:00:00"
+        time_animation = "false"
+        cloud_state = "free"
+        fog_range = "100000"
+        sun_intensity = "0.85"
+        sun_azimuth = "0"
+        sun_elevation = "1.31"
+        percip_type = "dry"
+        percip_intensity = "0"
+        
         try:
             env_layer = QgsProject.instance().mapLayersByName("Environment")[0]
             for feature in env_layer.getFeatures():


### PR DESCRIPTION
After the import (and modification) of an XOSC file without environment information, the export as XOSC fails with the following error:
```
An error has occurred while executing Python code: 

UnboundLocalError: local variable 'time_animation' referenced before assignment 
``` 

Therefore, set initial values for all environment variables in `export_xosc.py`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/traffic-generation-editor/13)
<!-- Reviewable:end -->
